### PR TITLE
Add GitHub Actions workflow for building toolchains

### DIFF
--- a/.github/workflows/toolchain_build.yml
+++ b/.github/workflows/toolchain_build.yml
@@ -1,0 +1,102 @@
+name: Build toolchains
+
+on:
+  push:
+    branches: ['master']
+    tags: ['*']
+  pull_request:
+    branches: ['master']
+
+env:
+  ARTIFACT_STAGING_DIR: artifact
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-20.04
+    timeout-minutes: 360
+
+    strategy:
+      matrix:
+        include:
+          - name: rv32imcb
+            target: riscv32-unknown-elf
+            output_dir: /tools/riscv
+            march: rv32imc_zba_zbb_zbc_zbs
+            mabi: ilp32
+            mcmodel: medany
+          - name: rv64imac
+            target: riscv64-unknown-elf
+            output_dir: /tools/riscv
+            march: rv64imac
+            mabi: lp64
+            mcmodel: medany
+#         - name: multilib-baremetal
+#           target: riscv64-unknown-elf
+#           output_dir: /opt/riscv-baremetal-toolchain
+#         - name: multilib-linux
+#           target: riscv64-unknown-linux-gnu
+#           output_dir: /opt/riscv-linux-toolchain
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        run: |
+          echo ::group::Install dependencies
+          ./prepare-ubuntu-20.04.sh
+          ./install-crosstool-ng.sh
+          echo ::endgroup::
+
+          echo Prepare toolchain destination directory
+          sudo mkdir -p /tools/riscv
+          sudo chmod 0777 /tools/riscv
+
+          echo ::group::Set the release tag env var
+          echo "RELEASE_TAG=$(./release_tag.sh)" >> "$GITHUB_ENV"
+          echo ::endgroup::
+
+          echo Create artifact staging directory.
+          mkdir "$ARTIFACT_STAGING_DIR"
+
+      - name: Build GCC toolchain
+        run: |
+          ./build-gcc-with-args.sh \
+            "lowrisc-toolchain-gcc-${{ matrix.name }}" \
+            "${{ matrix.target }}" \
+            "${{ matrix.output_dir }}" \
+            "${{ matrix.march }}" \
+            "${{ matrix.mabi}}" \
+            "${{ matrix.mcmodel }}" \
+            "${{ matrix.cflags }}"
+
+      - name: Build Clang toolchain
+        run: |
+          ./build-clang-with-args.sh \
+            "lowrisc-toolchain-${{ matrix.name }}" \
+            "${{ matrix.target }}" \
+            "${{ matrix.output_dir }}" \
+            "${{ matrix.march }}" \
+            "${{ matrix.mabi}}" \
+            "${{ matrix.mcmodel }}" \
+            "${{ matrix.cflags }}"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.name }}-toolchains
+          path: ${{ env.ARTIFACT_STAGING_DIR }}
+
+      - name: Check tarballs
+        run: |
+          set -e
+          for f in "${ARTIFACT_STAGING_DIR}"/*.tar.xz; do
+            ./check-tarball.sh "$f"
+          done
+
+      - name: Release
+        if: github.ref_type == 'tag'
+        run: |
+          gh release create \
+            "$ReleaseTag" \
+            --prerelease \
+            "${ARTIFACT_STAGING_DIR}/*-${RELEASE_TAG}.tar.xz"

--- a/_build-deps.yml
+++ b/_build-deps.yml
@@ -11,6 +11,15 @@ steps:
   displayName: 'Install build dependencies'
 
 - bash: |
+    # Explicitly include libtinfo in the ncurses linker options since it seems to be
+    # not picked up by configure itself, leading to the following error otherwise:
+    #
+    # /usr/local/bin/libtool  --tag CC  --mode=link gcc  -g -O2   -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o -lmenuw -lpanelw -lncursesw
+    # libtool: link: gcc -g -O2 -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o  -lmenuw -lpanelw -lncursesw
+    # /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: nconf-nconf.o: undefined reference to symbol 'keypad'
+    # //lib64/libtinfo.so.5: error adding symbols: DSO missing from command line
+    export CURSES_LIBS="-lcursesw -ltinfo"
+
     ./install-crosstool-ng.sh
   displayName: 'Build and install crosstool-ng'
 

--- a/install-crosstool-ng.sh
+++ b/install-crosstool-ng.sh
@@ -20,11 +20,4 @@ git checkout --force "${CROSSTOOL_NG_VERSION}"
 
 ./bootstrap
 
-# Explicitly include libtinfo in the ncurses linker options since it seems to be
-# not picked up by configure itself, leading to the following error otherwise:
-#
-# /usr/local/bin/libtool  --tag CC  --mode=link gcc  -g -O2   -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o -lmenuw -lpanelw -lncursesw
-# libtool: link: gcc -g -O2 -o nconf nconf-nconf.o nconf-nconf.gui.o nconf-zconf.o  -lmenuw -lpanelw -lncursesw
-# /opt/rh/devtoolset-8/root/usr/libexec/gcc/x86_64-redhat-linux/8/ld: nconf-nconf.o: undefined reference to symbol 'keypad'
-# //lib64/libtinfo.so.5: error adding symbols: DSO missing from command line
-CURSES_LIBS="-lcursesw -ltinfo" ./configure --prefix=/usr/local && make && sudo make install
+./configure --prefix=/usr/local && make && sudo make install

--- a/prepare-ubuntu-20.04.sh
+++ b/prepare-ubuntu-20.04.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -x
+
+# Install prerequisite packages.
+#
+# Notes:
+# - Python 2.7 or newer is required by the LLVM build system.
+# - liblzma-dev is removed to prevent it being dynamically linked to GDB.
+# - libxml2-dev is removed to prevent it being dynamically linked to LD.
+sudo apt install -y \
+  bison \
+  curl \
+  flex \
+  gawk \
+  gettext \
+  git \
+  help2man \
+  libffi-dev \
+  libncurses-dev \
+  libpixman-1-dev \
+  libtool-bin \
+  texinfo \
+  xz-utils \
+  zlib1g \
+  zlib1g-dev
+
+sudo apt remove -y \
+  liblzma-dev \
+  libxml2-dev

--- a/release_tag.sh
+++ b/release_tag.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Determine the release tag from Git based on the type of release being made.
+
+set -e
+set -x
+
+# Fetch all tags in case they didn't come with the checkout.
+git fetch --tags
+
+# git-describe --always almost does what we want, but we need to connect the
+# ReleaseTag variable contents to how this build was triggered, which we
+# will find out using `Build.SourceBranch` (a pipeline varaible).
+#
+# Importantly, a few things are going on here:
+# - If we were triggered by a tag, we need to output exactly the tag name,
+#   so that the artifacts are named correctly. If we cannot do this, the
+#   build needs to fail rather than uploading artifacts to some other
+#   random tag.
+# - If we were triggered by a branch build, we need to be more careful, as
+#   tagged commits are also pushed to branches. Branch builds explicitly use
+#   the longer format so that if the built commit matches a tag, the
+#   ReleaseTag is not a tag name.
+if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+  # Tag Build: Always use '<TAG>' format; Error if tag not found.
+  git describe --exact-match
+else
+  # Branch Build: Always use '<TAG>-<N>-<SHA>' format.
+  git describe --long
+fi


### PR DESCRIPTION
Notes:

* Switched to a matrix because the four builds are the same except for the flags to the build scripts.
* Shuffled around some of the tag stuff.
* Removed some ncurses setting from install-crosstool-ng because it was breaking the build on ubuntu.
* Haven't used the Centos 6 container yet because `actions/checkout` uses Node 20 and we ship 12 inside the container.
* [Centos 6.10](https://distrowatch.com/table.php?distribution=centos) has glibc 2.12 and [Ubuntu 20.04](https://distrowatch.com/table.php?distribution=ubuntu) has glibc 2.31 (22.04 has glibc 2.35).